### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/testpypi-publish.yml
+++ b/.github/workflows/testpypi-publish.yml
@@ -5,6 +5,9 @@ on:
     tags:
       - "v*"
 
+permissions:
+  contents: read
+
 jobs:
   build-and-publish:
     runs-on: ubuntu-22.04


### PR DESCRIPTION
Potential fix for [https://github.com/taggedzi/tzBJC/security/code-scanning/3](https://github.com/taggedzi/tzBJC/security/code-scanning/3)

To fix the issue, we will add a `permissions` block at the workflow level to explicitly define the minimal permissions required. Based on the workflow's operations, it primarily interacts with the repository contents (e.g., checking out code) and uses secrets for publishing to TestPyPI. Therefore, the `contents: read` permission is sufficient. This ensures the workflow has only the permissions it needs and no more.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
