### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/pypi-publish.yml
+++ b/.github/workflows/pypi-publish.yml
@@ -1,5 +1,8 @@
 name: Publish to PyPI
 
+permissions:
+  contents: read
+
 on:
   push:
     tags:


### PR DESCRIPTION
Potential fix for [https://github.com/taggedzi/tzBJC/security/code-scanning/1](https://github.com/taggedzi/tzBJC/security/code-scanning/1)

To fix the issue, we will add a `permissions` block at the workflow level (root) to explicitly define the permissions required. Based on the workflow's actions, it primarily interacts with the repository's contents to check out code and build the package. Therefore, the minimal required permission is `contents: read`. No additional permissions are needed for the `GITHUB_TOKEN`.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
